### PR TITLE
docs(readme): use full command name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ The main reason a MIDI handler was not implemented in Lua and thus directly into
 * All features from {url-lmi-features}[lilypond-midi-input], reflected during inserting/replacing of notes
 
 
-* Respects vim modes (see {url-vim-modes}[`:h vim-modes`])
+* Respects vim modes (see {url-vim-modes}[`:help vim-modes`])
 
 ** Notes are only inserted when in *Insert mode*
 ** Notes are replaced when in *Replace mode*

--- a/lua/nvim-midi-input/callbacks.lua
+++ b/lua/nvim-midi-input/callbacks.lua
@@ -1,7 +1,7 @@
 local debug = require('nvim-midi-input.debug')
 local options = require('nvim-midi-input.options')
 
----Table of callbacks for each desired mode. See `:h mode()`.
+---Table of callbacks for each desired mode. See `:help mode()`.
 ---@private
 local modeCallback = {
     ---Callback for insert mode


### PR DESCRIPTION
Use full command name.

Reference: https://neovim.io/doc/user/usr_02.html#02.8